### PR TITLE
feat: cross-promote Glitchgrab across the app

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,8 +454,15 @@ This project is open source and available under the [MIT License](LICENSE).
 - **Community**: Thanks to all Expo developers and contributors
 - **Technologies**: Built with amazing open source tools
 
+## 🧰 Also by us — Glitchgrab
+
+Building a Next.js or React Native app and tired of chasing messy bug reports? **[Glitchgrab](https://glitchgrab.dev/)** turns handwritten notes, screenshots, and production errors into structured GitHub issues using AI. Drop-in SDK for Next.js, mobile app, and Claude Desktop MCP server.
+
+👉 [Try Glitchgrab free →](https://glitchgrab.dev/)
+
 ## 🔗 Related Resources
 
+- **Glitchgrab**: [https://glitchgrab.dev/](https://glitchgrab.dev/) — AI bug reports → GitHub issues
 - **Expo Documentation**: [https://docs.expo.dev/](https://docs.expo.dev/)
 - **React Native Icons**: [https://reactnative.dev/docs/images](https://reactnative.dev/docs/images)
 - **Sharp Documentation**: [https://sharp.pixelplumbing.com/](https://sharp.pixelplumbing.com/)

--- a/app/_components/cross-promotion-banner.tsx
+++ b/app/_components/cross-promotion-banner.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { ExternalLink, QrCode, MonitorSmartphone } from "lucide-react";
+import { ExternalLink, QrCode, MonitorSmartphone, Bug } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -11,6 +11,15 @@ import {
 import { Badge } from "@/components/ui/badge";
 
 const PRODUCTS = [
+  {
+    icon: Bug,
+    title: "Glitchgrab — AI Bug Reports",
+    description: "Turn messy bug reports into structured GitHub issues",
+    detail:
+      "Drop a screenshot, note, or production error — Glitchgrab uses AI to generate a clean GitHub issue with title, labels, and severity. Built for Next.js teams.",
+    href: "https://glitchgrab.dev/",
+    cta: "Try Glitchgrab",
+  },
   {
     icon: QrCode,
     title: "Free QR Code Generator",
@@ -33,8 +42,8 @@ const PRODUCTS = [
 
 export default function CrossPromotionBanner() {
   return (
-    <div className="mx-auto max-w-5xl">
-      <div className="grid gap-4 sm:grid-cols-2">
+    <div className="mx-auto max-w-6xl">
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {PRODUCTS.map((product) => (
           <Card
             key={product.href}

--- a/app/_components/feedback-modal.tsx
+++ b/app/_components/feedback-modal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { MessageSquare, Check } from "lucide-react";
+import { MessageSquare, Check, Bug, ArrowUpRight } from "lucide-react";
 import { useMutation } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
@@ -124,13 +124,33 @@ export default function FeedbackModal({
     <Dialog open={isOpen} onOpenChange={handleClose}>
       <DialogContent className="max-w-sm">
         {feedbackMutation.isSuccess ? (
-          <div className="flex flex-col items-center py-8">
+          <div className="flex flex-col items-center py-6">
             <div className="mb-3 flex h-14 w-14 items-center justify-center rounded-full bg-green-900/50">
               <Check className="h-7 w-7 text-green-400" />
             </div>
             <p className="text-lg font-semibold text-white">
               Thanks for your feedback!
             </p>
+            <a
+              href="https://glitchgrab.dev/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-5 flex w-full items-start gap-3 rounded-lg border border-sky-900/60 bg-sky-950/40 p-3 transition-colors hover:border-sky-700 hover:bg-sky-950/70"
+            >
+              <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-sky-900/60">
+                <Bug className="h-4 w-4 text-sky-300" />
+              </div>
+              <div className="flex-1">
+                <p className="flex items-center gap-1.5 text-sm font-semibold text-white">
+                  Try Glitchgrab
+                  <ArrowUpRight className="h-3.5 w-3.5 text-sky-300" />
+                </p>
+                <p className="text-xs text-gray-400">
+                  Turn screenshots & messy bug reports into clean GitHub issues
+                  with AI.
+                </p>
+              </div>
+            </a>
           </div>
         ) : (
           <>

--- a/app/api/send-feedback/route.ts
+++ b/app/api/send-feedback/route.ts
@@ -47,6 +47,12 @@ export async function POST(request: NextRequest) {
       <hr>
       <p><em>Sent from Expo Icon Generator Feedback System</em></p>
       <p><em>Timestamp: ${new Date().toISOString()}</em></p>
+      <hr>
+      <p style="font-size: 12px; color: #555;">
+        Need to turn messy bug reports into clean GitHub issues? Try
+        <a href="https://glitchgrab.dev/" style="color: #0ea5e9; text-decoration: none; font-weight: 600;">Glitchgrab</a>
+        — AI-powered bug tracking for Next.js teams.
+      </p>
     `;
 
         // Send email

--- a/app/thanks-gift/page.tsx
+++ b/app/thanks-gift/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from "next";
 import Link from "next/link";
-import { Gift, Heart, Coffee, Sparkles, ArrowLeft } from "lucide-react";
+import { Gift, Heart, Coffee, Sparkles, ArrowLeft, Bug, ArrowUpRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { SupportButton } from "./support-button";
 
@@ -141,6 +141,36 @@ export default function ThanksGiftPage() {
               this tool. Your support means the world to us! 🌟
             </p>
           </div>
+
+          {/* Check out Glitchgrab */}
+          <Link
+            href="https://glitchgrab.dev/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="group mt-10 flex flex-col items-center gap-4 rounded-2xl border border-sky-900/60 bg-sky-950/30 p-8 text-center transition-colors hover:border-sky-700 hover:bg-sky-950/50 sm:flex-row sm:text-left"
+          >
+            <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-xl bg-sky-900/60">
+              <Bug className="h-7 w-7 text-sky-300" />
+            </div>
+            <div className="flex-1">
+              <div className="mb-1 flex items-center justify-center gap-2 sm:justify-start">
+                <h3 className="text-xl font-bold text-white">
+                  Check out Glitchgrab
+                </h3>
+                <span className="rounded-md bg-sky-900/60 px-2 py-0.5 text-[10px] font-semibold text-sky-300 uppercase">
+                  Also by us
+                </span>
+              </div>
+              <p className="text-sm text-gray-400">
+                Turn handwritten notes, screenshots, and production errors into
+                structured GitHub issues with AI. Built for Next.js teams.
+              </p>
+            </div>
+            <div className="flex items-center gap-1.5 text-sm font-semibold text-sky-300 group-hover:text-sky-200">
+              Try it free
+              <ArrowUpRight className="h-4 w-4" />
+            </div>
+          </Link>
 
           {/* Alternative Support */}
           <div className="mt-10 text-center">

--- a/components/utils/footer.tsx
+++ b/components/utils/footer.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import Image from "next/image";
-import { ExternalLink, Github, Linkedin, Globe, Mail, Chrome } from "lucide-react";
+import { ExternalLink, Github, Linkedin, Globe, Mail, Chrome, Bug } from "lucide-react";
 
 const NAV_LINKS = [
   { href: "/", label: "Home" },
@@ -130,6 +130,24 @@ export function Footer() {
                   </p>
                   <p className="text-[10px] text-gray-500">Current tool</p>
                 </div>
+              </li>
+              <li>
+                <Link
+                  href="https://glitchgrab.dev/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="group flex items-center justify-between rounded-lg border border-gray-800 p-2.5 transition-colors hover:border-gray-700 hover:bg-gray-900"
+                >
+                  <div>
+                    <p className="text-xs font-medium text-gray-300 group-hover:text-white">
+                      Glitchgrab
+                    </p>
+                    <p className="text-[10px] text-gray-500">
+                      AI bug reports → GitHub
+                    </p>
+                  </div>
+                  <Bug className="h-3 w-3 text-gray-600 group-hover:text-gray-400" />
+                </Link>
               </li>
               <li>
                 <Link


### PR DESCRIPTION
## Summary
Adds tasteful Glitchgrab (glitchgrab.dev) cross-promotion across the Expo Icon Generator app to drive traffic from active users (we're getting real feedback emails, so traffic is engaged).

## Placements
- **Home — cross-promotion banner** (`app/_components/cross-promotion-banner.tsx`): Glitchgrab added as first product card alongside QR Generator and NaviLens. Grid now 3-col on `lg`.
- **Global footer** (`components/utils/footer.tsx`): Glitchgrab link added to the Products section with a Bug icon.
- **Feedback modal success state** (`app/_components/feedback-modal.tsx`): after submitting feedback, users see a 'Try Glitchgrab' callout before the auto-redirect to the support page.
- **Feedback email template** (`app/api/send-feedback/route.ts`): email now includes a Glitchgrab signature footer — every feedback we receive reminds us of our own product.
- **Support page** (`app/thanks-gift/page.tsx`): full Glitchgrab promo card with 'Also by us' badge.
- **README**: new 'Also by us — Glitchgrab' section and resource link.

All links point to https://glitchgrab.dev with `rel=noopener noreferrer`. Copy is tasteful — positions Glitchgrab as a sibling developer tool, not a hard sell.

## Test plan
- [ ] Verify home page renders 3 product cards in the cross-promotion banner
- [ ] Verify footer Products section shows Glitchgrab with Bug icon
- [ ] Submit feedback → confirm Glitchgrab callout appears briefly before redirect to /thanks-gift
- [ ] Confirm /thanks-gift page shows the Glitchgrab promo card above 'Alternative Support'
- [ ] Trigger a test feedback email and confirm the footer signature renders
- [ ] Lint passes (`bun run lint`)