### PR TITLE
chore: sync Claude caller stubs

### DIFF
--- a/.github/workflows/claude-auto-fix.yml
+++ b/.github/workflows/claude-auto-fix.yml
@@ -6,74 +6,11 @@ on:
 
 jobs:
   auto-fix:
-    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
       issues: write
       id-token: write
       actions: read
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Setup Bun & install
-        uses: WebNaresh/bun-setup-action@v1
-        with:
-          bun-version: '1.3.7'
-
-      - name: Run Claude Code
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          additional_permissions: |
-            actions: read
-          claude_args: |
-            --permission-mode acceptEdits
-            --allowedTools "Bash,Edit,Write,Read,Glob,Grep,WebFetch"
-          prompt: |
-            Issue #${{ github.event.issue.number }} was just opened.
-
-            Title: ${{ github.event.issue.title }}
-            Author: ${{ github.event.issue.user.login }}
-            Assignees: ${{ join(github.event.issue.assignees.*.login, ',') }}
-
-            Body:
-            ${{ github.event.issue.body }}
-
-            STEP 1 — TRIAGE (mandatory, do this FIRST):
-            Decide whether this issue is a "simple bug fix" that you should auto-fix, or a "broader change" that needs human intervention. Err on the side of bailing out — if in doubt, do NOT open a PR.
-
-            Auto-fix ONLY if ALL of these are true:
-            - It is a clearly described bug with a reproducible symptom, a copy/text change, or a small UI tweak.
-            - The fix is confined to a small number of files and a localized code region.
-            - It requires NO database schema changes, NO migrations, and NO changes to `.env` / env var names.
-            - It requires NO new API route, NO new module, NO new page, and NO new dependency (no changes to `package.json` dependencies).
-            - It requires NO changes to auth, billing/payments, CI workflows (`.github/`), or build/config files.
-            - It does NOT touch more than ~5 files or ~150 lines total.
-            - The expected behavior is unambiguous from the issue body — no design decisions, no product judgment calls required.
-
-            DO NOT auto-fix (bail out) if ANY of these are true:
-            - Schema / migration / database structure changes are implied.
-            - It is a feature request, refactor, architectural change, or "broader" rework.
-            - It spans multiple packages or requires cross-cutting changes.
-            - It touches auth, payments, subscriptions, token/credential handling, or security-sensitive logic.
-            - The issue is vague, ambiguous, lacks repro steps, or needs clarification.
-            - Fixing it safely would require human product/design judgment.
-
-            If you decide to bail out: post ONE comment on the issue explaining that this looks like a broader change needing human intervention, briefly state why (schema change / feature / ambiguous / etc.), assign the issue to the repo owner with `gh issue edit ${{ github.event.issue.number }} --add-assignee ${{ github.repository_owner }}`, and STOP. Do NOT create a branch, do NOT open a PR.
-
-            STEP 2 — FIX (only if triage passed):
-            1. Investigate the issue. Read relevant code and confirm the bug before making changes.
-            2. Create and switch to a new branch named `claude/issue-${{ github.event.issue.number }}` based on the default branch.
-            3. Implement the fix. Follow existing code style and patterns in the repo.
-            4. Run the project's build/validate command (bun run build). If anything fails, fix it before committing.
-            5. Commit each changed file individually using conventional commit format (e.g. `fix(scope): ...`). Do NOT add any Co-Authored-By or Claude attribution lines.
-            6. Push the branch to origin.
-            7. Open a pull request targeting the default branch using `gh pr create`. Include the line `Closes #${{ github.event.issue.number }}` in the PR body so GitHub auto-closes the issue when the PR merges. Pass `--assignee` with the issue's assignees (comma-separated). If the issue has no assignees, use the issue author `${{ github.event.issue.user.login }}` as the assignee.
-            8. Post a single comment on the issue linking to the new PR.
-            9. NEVER run `gh pr merge` — the repo owner handles merging.
-
-            If at any point during the fix you discover the change is broader than the triage suggested (e.g. you need a schema change, a new dependency, or design decisions), STOP, discard the branch, post a comment on the issue explaining this needs human intervention, and assign the issue to the repo owner with `gh issue edit ${{ github.event.issue.number }} --add-assignee ${{ github.repository_owner }}`.
+    uses: Navibyte-Innovations-Pvt-Ltd/.github/.github/workflows/claude-auto-fix-reusable.yml@main
+    secrets: inherit

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,48 +12,11 @@ on:
 
 jobs:
   claude:
-    if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
       issues: write
       id-token: write
       actions: read
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Run Claude Code
-        id: claude
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          additional_permissions: |
-            actions: read
-          claude_args: |
-            --permission-mode acceptEdits
-            --allowedTools "Bash,Edit,Write,Read,Glob,Grep,WebFetch"
-          prompt: |
-            You were tagged via @claude on ${{ github.event_name }} in repo ${{ github.repository }}.
-
-            Follow the user's instructions in the triggering comment/issue/review.
-
-            If the task requires code changes on an issue (not already on a PR branch):
-            1. Create a branch named `claude/issue-${{ github.event.issue.number }}` (or a unique name if that exists).
-            2. Implement the fix following existing code style.
-            3. Commit each changed file individually using conventional commit format (e.g. `fix(scope): ...`). Never add Co-Authored-By or any Claude attribution.
-            4. Push the branch to origin.
-            5. Open a pull request to the default branch using `gh pr create`. Put `Closes #${{ github.event.issue.number }}` in the PR body so the issue auto-closes on merge. Pass `--assignee` with the issue's assignees (comma-separated list from `${{ join(github.event.issue.assignees.*.login, ',') }}`). If that list is empty, use the issue author `${{ github.event.issue.user.login }}`.
-            6. Post a single comment on the issue linking to the PR.
-            7. NEVER run `gh pr merge` — the repo owner handles merging.
-
-            If the task is on an existing PR (review/comment), push commits to that PR's branch directly; do not open a new PR.
-
-            If you cannot solve the task (ambiguous, out of scope, requires human judgment, or you hit a blocker): post ONE comment on the issue/PR explaining why, and — only if the trigger is an issue — assign it to the repo owner with `gh issue edit ${{ github.event.issue.number }} --add-assignee ${{ github.repository_owner }}`. Do NOT open a PR.
+    uses: Navibyte-Innovations-Pvt-Ltd/.github/.github/workflows/claude-reusable.yml@main
+    secrets: inherit


### PR DESCRIPTION
Automated sync from central `.github` repo. Keeps `.github/workflows/claude.yml` and `.github/workflows/claude-auto-fix.yml` aligned with the org reusable workflows.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Navibyte-Innovations-Pvt-Ltd/codesmith/expo-icon-generator/pr/31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->