### PR TITLE
feat(glitchgrab): integrate Glitchgrab SDK for bug reporting

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef } from "react";
+import { Bug } from "lucide-react";
 import {
   HeroSection,
   FileUploadArea,
@@ -50,6 +51,27 @@ function buildAppJson(
     },
   };
   return JSON.stringify(config, null, 2);
+}
+
+function ReportBugSection() {
+  const handleClick = () => {
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(new CustomEvent("glitchgrab:open-report"));
+    }
+  };
+  return (
+    <div className="mt-16 flex flex-col items-center gap-3 border-t border-gray-800 pt-12 text-center">
+      <p className="text-sm text-gray-500">Found something broken?</p>
+      <button
+        type="button"
+        onClick={handleClick}
+        className="flex items-center gap-2 rounded-full border border-gray-700 bg-gray-900 px-5 py-2.5 text-sm font-medium text-gray-300 transition-colors hover:border-gray-600 hover:bg-gray-800 hover:text-white"
+      >
+        <Bug className="h-4 w-4 text-sky-400" />
+        Report a Bug
+      </button>
+    </div>
+  );
 }
 
 export default function HomePage() {
@@ -239,6 +261,7 @@ export default function HomePage() {
         <ComprehensiveGuideSection />
         <TechnicalSpecificationsSection />
         <AppStoreOptimizationSection />
+        <ReportBugSection />
       </div>
 
       <FeedbackModal

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -2,6 +2,9 @@
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useState } from "react";
+import { GlitchgrabProvider, ReportButton } from "glitchgrab";
+
+const GLITCHGRAB_TOKEN = process.env.NEXT_PUBLIC_GLITCHGRAB_TOKEN ?? "";
 
 export function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(
@@ -9,7 +12,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
       new QueryClient({
         defaultOptions: {
           queries: {
-            staleTime: 60 * 1000, // 1 minute
+            staleTime: 60 * 1000,
             retry: 1,
           },
           mutations: {
@@ -20,6 +23,11 @@ export function Providers({ children }: { children: React.ReactNode }) {
   );
 
   return (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    <QueryClientProvider client={queryClient}>
+      <GlitchgrabProvider token={GLITCHGRAB_TOKEN}>
+        {children}
+        <ReportButton position="bottom-right" label="Report Bug" />
+      </GlitchgrabProvider>
+    </QueryClientProvider>
   );
 }

--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
         "@types/nodemailer": "^7.0.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "glitchgrab": "^1.17.1",
         "jspdf": "^3.0.1",
         "jszip": "^3.10.1",
         "lucide-react": "^0.525.0",
@@ -1034,6 +1035,8 @@
 
     "git-raw-commits": ["git-raw-commits@4.0.0", "", { "dependencies": { "dargs": "^8.0.0", "meow": "^12.0.1", "split2": "^4.0.0" }, "bin": { "git-raw-commits": "cli.mjs" } }, "sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ=="],
 
+    "glitchgrab": ["glitchgrab@1.17.1", "", { "dependencies": { "html2canvas-pro": "^2.0.2" }, "peerDependencies": { "next": ">=13", "react": ">=18", "react-dom": ">=18" } }, "sha512-q0Glp0DiHHcMpG0ZQpXnBqhYkA5DeULK0yCdCUQQMtVx1647srM5wLViQAFzkSFfJFRNbRNxB/ZvgMAIQZNqkw=="],
+
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
     "global-directory": ["global-directory@4.0.1", "", { "dependencies": { "ini": "4.1.1" } }, "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q=="],
@@ -1077,6 +1080,8 @@
     "hosted-git-info": ["hosted-git-info@9.0.2", "", { "dependencies": { "lru-cache": "^11.1.0" } }, "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg=="],
 
     "html2canvas": ["html2canvas@1.4.1", "", { "dependencies": { "css-line-break": "^2.1.0", "text-segmentation": "^1.0.3" } }, "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA=="],
+
+    "html2canvas-pro": ["html2canvas-pro@2.0.2", "", { "dependencies": { "css-line-break": "^2.1.0", "text-segmentation": "^1.0.3" } }, "sha512-9G/t0XgCZWonLwL0JwI7su6NdbOPUY7Ur4Ihpp8+XMaW9ibA2nDXF181Jr6tm94k8lX6sthpaXB3XqEnsMd5Cw=="],
 
     "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@types/nodemailer": "^7.0.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "glitchgrab": "^1.17.1",
     "jspdf": "^3.0.1",
     "jszip": "^3.10.1",
     "lucide-react": "^0.525.0",


### PR DESCRIPTION
## Summary
- Adds `glitchgrab` npm SDK to auto-capture unhandled errors in production and send them to GitHub Issues via AI
- Wraps entire app in `GlitchgrabProvider` with floating "Report Bug" button (bottom-right)
- Adds `ReportBugSection` at bottom of home page — inline button opens Glitchgrab report dialog via custom event dispatch (no provider hook dependency)

## Changes
 app/page.tsx      | 23 +++++++++++++++++++++++
 app/providers.tsx | 12 ++++++++++--
 bun.lock          |  5 +++++
 package.json      |  1 +
 4 files changed, 39 insertions(+), 2 deletions(-)

## CI Pre-check
| Check | Status |
|-------|--------|
| lint | ✅ passed |
| build | ✅ passed |

## Test plan
- [ ] Visit home page — verify "Report a Bug" button visible at bottom
- [ ] Click button — verify Glitchgrab report dialog opens
- [ ] Submit a bug report — verify it appears in Glitchgrab dashboard
- [ ] Trigger a JS error in production — verify auto-capture creates GitHub issue
- [ ] Confirm floating "Report Bug" button appears bottom-right on all pages
- [ ] Set `NEXT_PUBLIC_GLITCHGRAB_TOKEN` in Vercel env vars for production

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Navibyte-Innovations-Pvt-Ltd/codesmith/expo-icon-generator/pr/34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->